### PR TITLE
Fixed bug on absent fts indexes.

### DIFF
--- a/cluster_manager.py
+++ b/cluster_manager.py
@@ -136,6 +136,9 @@ class ClusterManager(object):
         if errors:
             return None, errors
 
+        if result["indexDefs"] is None:
+            return None, None
+
         bucket_index_defs = []
         for _, index_def in result["indexDefs"]["indexDefs"].iteritems():
             if index_def["sourceType"] == "couchbase" and index_def["sourceName"] == bucket:
@@ -329,7 +332,7 @@ class ClusterManager(object):
     def get_server_group(self, groupName):
         groups, errors = self.get_server_groups()
         if errors:
-            return None, error
+            return None, errors
 
         if not groups or not groups["groups"] or groups["groups"] == 0:
             return None, ["No server groups found"]


### PR DESCRIPTION
Hi, there was a bug introduced with implementation of FTS backup functionality. It is triggered when there are no FTS indexes present.
```bash
Traceback (most recent call last):
  File "/home/ubuntu/temp/couchbase-cli/cbbackup", line 12, in <module>
    pump_transfer.exit_handler(pump_transfer.Backup().main(sys.argv))
  File "/home/ubuntu/temp/couchbase-cli/pump_transfer.py", line 81, in main
    rv = pumpStation.run()
  File "/home/ubuntu/temp/couchbase-cli/pump.py", line 146, in run
    rv = self.transfer_bucket_fts_index(source_bucket, source_map, sink_map)
  File "/home/ubuntu/temp/couchbase-cli/pump.py", line 289, in transfer_bucket_fts_index
    source_bucket, source_map)
  File "/home/ubuntu/temp/couchbase-cli/pump_dcp.py", line 108, in provide_fts_index
    result, errors = rest.get_fts_index_metadata(source_bucket['name'])
  File "/home/ubuntu/temp/couchbase-cli/cluster_manager.py", line 140, in get_fts_index_metadata
    for _, index_def in result["indexDefs"]["indexDefs"].iteritems():
TypeError: 'NoneType' object has no attribute '__getitem__'
```