### PR TITLE
Allow the credentials to be read in from environment variables

### DIFF
--- a/pump_transfer.py
+++ b/pump_transfer.py
@@ -173,10 +173,10 @@ from a source cluster into the caching layer at the destination""")
                      help="""No actual transfer; just validate parameters, files,
                              connectivity and configurations""")
         p.add_option("-u", "--username",
-                     action="store", type="string", default=None,
+                     action="store", type="string", default=os.environ.get("CB_USERNAME"),
                      help="REST username for source cluster or server node")
         p.add_option("-p", "--password",
-                     action="store", type="string", default=None,
+                     action="store", type="string", default=os.environ.get("CB_PASSWORD"),
                      help="REST password for source cluster or server node")
         p.add_option("-s", "--ssl",
                      action="store_true", default=False,


### PR DESCRIPTION
Read `username` and `password` from the environment variables CB_USERNAME & CB_PASSWORD as defaults when not specified on the command line.

When environment variables are used it means that credentials are not exposed in the process list which is visible to all users on the host.

Typical usage could be:

e.g. in file /etc/couchbase/credentials
````
CB_USERNAME=username
CB_PASSWORD=password
````

Followed by sourcing the credentials file and running cbbackup like so
`. ./etc/couchbase/credentials cbbackup http://localhost:8091 /backups/couchbase`
