### PR TITLE
Adding multi-bucket support for cbbackup

### DIFF
--- a/pump.py
+++ b/pump.py
@@ -186,13 +186,17 @@ class PumpingStation(ProgressReporter):
         logging.debug("source_buckets: " +
                       ",".join([n['name'] for n in source_buckets]))
 
-        bucket_source = getattr(self.opts, "bucket_source", None)
-        if bucket_source:
-            logging.debug("bucket_source: " + bucket_source)
-            source_buckets = [b for b in source_buckets
-                              if b['name'] == bucket_source]
+        buckets_source = set(getattr(self.opts, "bucket_source", []))
+        if buckets_source:
+            buckets_source_list = []
+            for bucket_source in buckets_source:
+                logging.debug("bucket_source: " + bucket_source)
+                buckets_source_list.extend([b for b in source_buckets
+                                            if b['name'] == bucket_source])
+            source_buckets = buckets_source_list
             logging.debug("source_buckets filtered: " +
-                          ",".join([n['name'] for n in source_buckets]))
+                            ",".join([n['name'] for n in source_buckets]))
+
         return source_buckets
 
     def filter_source_nodes(self, source_bucket, source_map):
@@ -1083,7 +1087,8 @@ def find_source_bucket_name(opts, source_map):
         source_bucket = source_map['buckets'][0]['name']
     if not source_bucket:
         return "error: please specify a bucket_source", None
-    logging.debug("source_bucket: " + source_bucket)
+    for bucket in source_bucket:
+        logging.debug("source_bucket: " + bucket)
     return 0, source_bucket
 
 def find_sink_bucket_name(opts, source_bucket):

--- a/pump_transfer.py
+++ b/pump_transfer.py
@@ -136,7 +136,7 @@ class Transfer:
 
     def opt_parser_options(self, p):
         p.add_option("-b", "--bucket-source",
-                     action="append", type="string", default=[],
+                     action="store", type="string", default=None,
                      help="""Single named bucket from source cluster to transfer""")
         p.add_option("-B", "--bucket-destination",
                      action="store", type="string", default=None,
@@ -273,8 +273,8 @@ class Backup(Transfer):
 
     def opt_parser_options(self, p):
         p.add_option("-b", "--bucket-source",
-                     action="store", type="string", default=None,
-                     help="""single bucket from source to backup""")
+                     action="append", type="string", default=[],
+                     help="""single or multiple buckets from source to backup""")
         p.add_option("", "--single-node",
                      action="store_true", default=False,
                      help="""use a single server node from the source only,

--- a/pump_transfer.py
+++ b/pump_transfer.py
@@ -136,7 +136,7 @@ class Transfer:
 
     def opt_parser_options(self, p):
         p.add_option("-b", "--bucket-source",
-                     action="store", type="string", default=None,
+                     action="append", type="string", default=[],
                      help="""Single named bucket from source cluster to transfer""")
         p.add_option("-B", "--bucket-destination",
                      action="store", type="string", default=None,


### PR DESCRIPTION
**Summary:**
While doing backups using `cbbackup` we have only two options when choosing the `bucket_source`: either all buckets or only single bucket. So: 
*  choosing the option of `all buckets` (which is default if you don't specify any buckets) we're getting the backup of all buckets, without option to choose which buckets you would like to skip. 
*  choosing the option of `custom bucket` by adding **arg** `-b bucket_name` we are limited to only one bucket per backup. 

**Problem:**
When having a **custom list** `-b bucket_1 -b bucket_2 -b bucket_3` of buckets that we want to backup, there is no option to specify them. We can automate this by a loop:
```
buckets = [ "bucket_1", "bucket_2", "bucket_3" ]
for bucket in buckets:
  cbbackup http://[host]:[port] /path/for/backup` -u [user] -p [password] -b bucket
```
 and perform backup for each bucket separately, **but** this will create a new folder for each bucket with `timestamp` and other two subfolders. When having multiple Couchbase clusters, using the aforementioned **loop** and multiple folders would create a mess and would be hard to understand which backup (folder) is for which bucket.

**Steps to reproduce**
In order to reproduce, you can run the following command: `cbbackup http://[host]:[port] /path/for/backup` -u [user] -p [password] -b bucket_1 -b bucket_2 -b bucket_3`. What you will get is the backup for the last bucket specified, in our case backup for only `bucket_3`.

**Potential solution:**
In this PR we are adding support for multiple buckets: `cbbackup http://[host]:[port] /path/for/backup -u [user] -p [password] -b bucket_1 -b bucket_2 -b bucket_3`. By doing this, user will be able to create single backup of multiple buckets in a single folder with the timestamp on it.
