### PR TITLE
Fix cbbackup and global cluster management in remote environment

### DIFF
--- a/cluster_manager.py
+++ b/cluster_manager.py
@@ -212,9 +212,10 @@ class ClusterManager(object):
         if errors:
             return None, errors
 
+        parsed = urlparse.urlparse(self.hostname)
         hosts = []
         for node in data['nodesExt']:
-            node_host = '127.0.0.1'
+            node_host = parsed.hostname
             if 'hostname' in node:
                 node_host = node['hostname']
 


### PR DESCRIPTION
Hi there,

### Setup ###
- A 1 node dockerised couchbase cluster (Yes I know, not recommended)
- 1 separate container to handle maintenance (backup mostly)

### Problem ###
For some reason cbbackup wasn't working properly (Unable to backup fts indexes)
Here is the output I had:
```
root@somehost:/# cbbackup couchbase://cbnode1:8091 /opt/couchbase/var/lib/couchbase/backup -u Administrator -p password
  [####################] 100.0% (33/estimated 33 msgs)
bucket: default, msgs transferred...
       :                total |       last |    per sec
 byte  :                32958 |      32958 |    19765.3
2018-10-12 14:36:27,151: mt ['unable to access the REST API - please check your username (-u) and password (-p)']
Traceback (most recent call last):
  File "/opt/couchbase/lib/python/cbbackup", line 12, in <module>
    pump_transfer.exit_handler(pump_transfer.Backup().main(sys.argv))
  File "/opt/couchbase/lib/python/pump_transfer.py", line 80, in main
    rv = pumpStation.run()
  File "/opt/couchbase/lib/python/pump.py", line 150, in run
    rv = self.transfer_bucket_fts_index(source_bucket, source_map, sink_map)
  File "/opt/couchbase/lib/python/pump.py", line 293, in transfer_bucket_fts_index
    source_bucket, source_map)
  File "/opt/couchbase/lib/python/pump_dcp.py", line 142, in provide_fts_index
    result, errors = rest.get_fts_index_metadata(source_bucket['name'])
  File "/opt/couchbase/lib/python/cluster_manager.py", line 139, in get_fts_index_metadata
    result, errors = self._get(url)
  File "/opt/couchbase/lib/python/cluster_manager.py", line 33, in g
    return f(*args, **kwargs)
  File "/opt/couchbase/lib/python/cluster_manager.py", line 1367, in _get
    return _handle_response(response, self.debug)
  File "/opt/couchbase/lib/python/cluster_manager.py", line 1451, in _handle_response
    return None, [errors["message"] + ": " + ", ".join(errors["permissions"])]
KeyError: 'message'
```
The error was comming from this call https://github.com/couchbase/couchbase-cli/blob/master/cluster_manager.py#L152 

I manually sent a '/pools/default/nodeServices' call to the rest API and found out that `hostname` field was missing from the JSON response so by default [`get_hostnames_for_service`](https://github.com/couchbase/couchbase-cli/blob/master/cluster_manager.py#L217-L219) was using `127.0.0.1` as hostname value. 
Here is '/nodeServices' JSON output
```json
{
    "rev": 26,
    "nodesExt": [
        {
            "services": {
                "mgmt": 8091,
                "mgmtSSL": 18091,
                "eventingAdminPort": 8096,
                "eventingSSL": 18096,
                "fts": 8094,
                "ftsSSL": 18094,
                "indexAdmin": 9100,
                "indexScan": 9101,
                "indexHttp": 9102,
                "indexStreamInit": 9103,
                "indexStreamCatchup": 9104,
                "indexStreamMaint": 9105,
                "indexHttps": 19102,
                "capiSSL": 18092,
                "capi": 8092,
                "kvSSL": 11207,
                "projector": 9999,
                "kv": 11210,
                "moxi": 11211,
                "n1ql": 8093,
                "n1qlSSL": 18093
            },
            "thisNode": true
        }
    ]
}
```

Instead of `127.0.0.1` this PR sets the default value to the current node's hostname.
I tested it and backup worked perfectly.

Hope that helps!