### PR TITLE
broken man link fix

### DIFF
--- a/docs/modules/cli/pages/cbcli/couchbase-cli.adoc
+++ b/docs/modules/cli/pages/cbcli/couchbase-cli.adoc
@@ -29,7 +29,7 @@ cluster management.
 
 == COMMANDS
 
-man:couchbase-cli-admin-role-manage[1]::
+man:couchbase-cli-user-manage[1]::
   Manage LDAP user roles.
 
 man:couchbase-cli-bucket-compact[1]::


### PR DESCRIPTION
The link currently appears broken on the site.

![broken link](https://user-images.githubusercontent.com/103484/80606338-34e1c380-8a02-11ea-9324-f99df6bca0db.png)

I believe this is because the page it's referring to doesn't exist (anymore). It redirects to the page in the PR.