### PR TITLE
Correct the master-password instructions

### DIFF
--- a/docs/modules/cli/pages/cbcli/couchbase-cli-master-password.adoc
+++ b/docs/modules/cli/pages/cbcli/couchbase-cli-master-password.adoc
@@ -28,10 +28,10 @@ By default the Secret Management feature is disabled. To enable the feature,
 you must first set the master password. Once a master password is set, the
 user is required to enter it when the server starts up. This can be done by
 setting the environment variable CB_MASTER_PASSWORD=<password> during server
-startup. Alternatively, you can set the environment variable
-CB_WAIT_FOR_MASTER_PASSWORD=true, and then enter the master password using the
-couchbase-cli master-password command. This command must be run locally on the
-node that needs to be unlocked.
+startup. Alternatively, you can enter the master password using the 
+couchbase-cli `master-password` command. This command must be run locally on 
+the node that needs to be unlocked and the user running the command must be
+a member of the `couchbase` group (or be root.)
 
 == OPTIONS
 
@@ -53,18 +53,13 @@ for your server.
   $ couchbase-cli setting-master-password -c 127.0.0.1 -u Administrator \
     -p password --new-password password
 
-Once the master password has been set, you need to set the server environment
-variable CB_WAIT_FOR_MASTER_PASSWORD=true. You can do this by running the
-command below or by setting the variable in your .bashrc file.
-
-  $ export CB_WAIT_FOR_MASTER_PASSWORD=true
-
-This environment variable will cause Couchbase to wait for the master password
-before starting up. Once it is set, you need to restart your cluster. Upon
-restarting the cluster you will notice that the server doesn't fully start.
-This is because it is waiting for you to enter the master password. You can do
-this by running the command below. The master-password subcommand has to be
-run locally on the node that is waiting for the master password.
+This will cause Couchbase Server to wait for the master password
+before starting up. When your cluster is restarted, you will notice that the 
+server doesn't fully come up as it is now waiting for the master password to 
+be entered. You can do this by running the command below. The master-password 
+subcommand has to be run locally on the node that is waiting for the master 
+password and as the user must have be able to read files in the `couchbase`
+group.
 
   $ couchbase-cli master-password --send-password password
 


### PR DESCRIPTION
(1) Mention that the user running the command must
    be part of the couchbase group
(2) Remove the references to CB_WAIT_FOR_MASTER_PASSWORD
    which isn't used anymore.

Note that we filed DOC-2222 on this years ago when 4.6.2 was shipped, 
but I guess this page was missed.