### PR TITLE
Update couchbase-cli reset-admin-password --regenerate example

### DIFF
--- a/docs/modules/cli/pages/cbcli/couchbase-cli-reset-admin-password.adoc
+++ b/docs/modules/cli/pages/cbcli/couchbase-cli-reset-admin-password.adoc
@@ -55,7 +55,7 @@ To change the administrator password to a randomly generated value, run the
 following command. The new password will be printed to stdout if the
 password is successfully changed:
 ----
-$ couchbase-cli reset-admin-password --regenerate jXjNW6LG
+$ couchbase-cli reset-admin-password --regenerate
 ----
 == SEE ALSO
 


### PR DESCRIPTION
Doesn't need extra chars.