### PR TITLE
Fixed add_active_repository - modified name of cloud region and added…

### DIFF
--- a/cbmgr.py
+++ b/cbmgr.py
@@ -5503,11 +5503,13 @@ class BackupServiceRepository:
         if kwargs.get('credentials_key', False):
             add_request_body['cloud_credentials_key'] = kwargs.get('credentials_key')
         if kwargs.get('cloud_region', False):
-            add_request_body['cloud_credentials_region'] = kwargs.get('cloud_region')
+            add_request_body['cloud_region'] = kwargs.get('cloud_region')
         if kwargs.get('cloud_endpoint', False):
             add_request_body['cloud_endpoint'] = kwargs.get('cloud_endpoint')
         if kwargs.get('s3_path_style', False):
             add_request_body['cloud_force_path_style'] = kwargs.get('s3_path_style')
+        if kwargs.get('staging_dir', False):
+            add_request_body['cloud_staging_dir'] = kwargs.get('staging_dir')
 
         _, errors = self.rest.add_backup_active_repository(repository_id, add_request_body)
         _exit_if_errors(errors)


### PR DESCRIPTION
Fixed bug with being unable to add new active backup repository via couchbase-cli.
It seems like staging directory was not passed to REST API call body, it implied 400 error, saying that cloud directory must be supplied. Moreover passing cloud credentials region was incorrect, REST API was expecting "cloud_region" parameter, "cloud_credentials_region" was passed instead.