### PR TITLE
Update couchbase-cli-reset-admin-password.adoc

### DIFF
--- a/docs/modules/cli/pages/cbcli/couchbase-cli-reset-admin-password.adoc
+++ b/docs/modules/cli/pages/cbcli/couchbase-cli-reset-admin-password.adoc
@@ -65,7 +65,8 @@ To change the administrator password to a randomly generated value, run the
 following command. The new password will be printed to stdout if the
 password is successfully changed:
 ----
-$ couchbase-cli reset-admin-password --regenerate jXjNW6LG
+$ couchbase-cli reset-admin-password --regenerate 
+jXjNW6LG
 ----
 == SEE ALSO
 


### PR DESCRIPTION
new password will be printed to stdout on the next line, whereas the current text makes it look like the example is providing the string jXjNW6LG as input.